### PR TITLE
思源现在已经支持文档的 wiki 链接导入了

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,7 +123,8 @@ function 解析一行文本(line, list, item) {
             links: links,
         };
     }
-    const regexWikiGlobal = /\[\[([^\]]*)\]\]/g;
+    // const regexWikiGlobal = /\[\[([^\]]*)\]\]/g;
+    const regexWikiGlobal = /\[\[([^\].]*\.[^\]]*)\]\]/g;
     let wikiMatches = line.match(regexWikiGlobal);
 
     if (!wikiMatches) {


### PR DESCRIPTION
思源笔记版本：3.0.2
- 匹配改为 `const regexWikiGlobal = /\[\[([^\].]*\.[^\]]*)\]\]/g;`，只转换名称带`.`（资源文件）的 wiki 链接。