### PR TITLE
忽略无后缀（markdown）文件的双链引用处理

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,14 +133,16 @@ function 解析一行文本(line, list, item) {
         };
     }
     wikiMatches.forEach(wikilink => {
-        let {start, end, alias, name, fileName, query, path} = parseWikiLink(wikilink, line, list,item.targetFilePath);
-        links.push({
-            href:path,
-            query:query,
-            hrefName: fileName,
-            alias: alias
-        });
-        magicline.overwrite(start, end, `[${alias}](${path}${query})`);
+        let {start, end, alias, name, fileName, query, path, needTrans} = parseWikiLink(wikilink, line, list,item.targetFilePath);
+        if (needTrans) {
+            links.push({
+                href:path,
+                query:query,
+                hrefName: fileName,
+                alias: alias
+            });
+            magicline.overwrite(start, end, `[${alias}](${path}${query})`);
+        }
     });
     return {
         markdown: magicline.toString(),
@@ -149,6 +151,7 @@ function 解析一行文本(line, list, item) {
 }
 
 function parseWikiLink(wikilink, line, list, currentFilePath) {
+    let needTrans = true;
     let start = line.indexOf(wikilink);
     let end = start + wikilink.length;
     let alias = wikilink.split("|")[1];
@@ -169,6 +172,8 @@ function parseWikiLink(wikilink, line, list, currentFilePath) {
     let query = name.replace(fileName, "");
     if ((fileName.indexOf("\.") < 0)) {
         fileName = fileName + '.md';
+        // 忽略markdown文件翻译
+        needTrans = false;
     }
     fileName = fileName;
     query = query;
@@ -184,5 +189,5 @@ function parseWikiLink(wikilink, line, list, currentFilePath) {
     // Convert the path to a relative path
     _path = path.relative(path.dirname(currentFilePath), _path);
 
-    return {start, end, alias, name, fileName, query, path:_path};
+    return {start, end, alias, name, fileName, query, path:_path, needTrans};
 }


### PR DESCRIPTION
今天帮师弟从obsidian转到思源，发现如果没有经过处理，思源并不会自动转化资源文件，但是经过这个插件处理之后，资源文件能够成功导入，而文件的引用反而不行了。

查看代码后发现是因为相对路径的双链被处理成链接，但是此时的思源没法处理这种链接，反而可以处理本身的双链，因此改了下代码，把无后缀的引用不作处理，基本能算是完美导入了。